### PR TITLE
[JDBC 라이브러리] 션 미션 제출합니다.

### DIFF
--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -4,9 +4,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class JdbcTemplate {
     private static final Logger logger = LoggerFactory.getLogger(JdbcTemplate.class);
@@ -35,11 +40,43 @@ public class JdbcTemplate {
         }
     }
 
+    public <T> List<T> query(String query, Class<?> clazz, Object... objects) {
+        List<T> results = new ArrayList<>();
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, query, objects);
+             ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                T t = getResult(rs, clazz);
+                results.add(t);
+            }
+        } catch (Exception e) {
+            logger.error("Error occurred while executing Query", e);
+            throw new JdbcTemplateException(e);
+        }
+        return results;
+    }
+
     private PreparedStatement createPreparedStatement(Connection con, String sql, Object... objects) throws SQLException {
         PreparedStatement pstmt = con.prepareStatement(sql);
         for (int i = 0; i < objects.length; i++) {
             pstmt.setObject(i + 1, objects[i]);
         }
         return pstmt;
+    }
+
+    private <T> T getResult(ResultSet rs, Class<?> clazz) throws Exception {
+        Object instance = clazz.getConstructor().newInstance();
+        Arrays.stream(clazz.getFields()).forEach(field -> setField(rs, instance, field));
+        return (T) instance;
+    }
+
+    private void setField(ResultSet rs, Object instance, Field field) {
+        try {
+            field.setAccessible(true);
+            field.set(instance, rs.getObject(field.getName()));
+        } catch (IllegalAccessException | SQLException e) {
+            logger.error("Error occurred while setting Field", e);
+            throw new JdbcTemplateException(e);
+        }
     }
 }

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -1,4 +1,39 @@
 package nextstep.jdbc;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 public class JdbcTemplate {
+    private static JdbcTemplate jdbcTemplate;
+    private DataSource dataSource;
+
+    private JdbcTemplate(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public static JdbcTemplate getInstance(DataSource dataSource) {
+        if (jdbcTemplate == null) {
+            return new JdbcTemplate(dataSource);
+        }
+        return jdbcTemplate;
+    }
+
+    public void executeQuery(String query, Object... objects) {
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, query, objects)) {
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            // TODO: 2019-10-15
+        }
+    }
+
+    private PreparedStatement createPreparedStatement(Connection con, String sql, Object... objects) throws SQLException {
+        PreparedStatement pstmt = con.prepareStatement(sql);
+        for (int i = 0; i < objects.length; i++) {
+            pstmt.setObject(i + 1, objects[i]);
+        }
+        return pstmt;
+    }
 }

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -71,6 +71,21 @@ public class JdbcTemplate {
         return result;
     }
 
+    public <T> T queryForObject(String query, RowMapper rowMapper, Object... objects) {
+        T result = null;
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, query, objects);
+             ResultSet rs = pstmt.executeQuery()) {
+            if (rs.next()) {
+                result = (T) rowMapper.mapRow(rs);
+            }
+        } catch (Exception e) {
+            logger.error("Error occurred while executing Query", e);
+            throw new JdbcTemplateException(e);
+        }
+        return result;
+    }
+
     private PreparedStatement createPreparedStatement(Connection con, String sql, Object... objects) throws SQLException {
         PreparedStatement pstmt = con.prepareStatement(sql);
         for (int i = 0; i < objects.length; i++) {

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -1,11 +1,16 @@
 package nextstep.jdbc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 public class JdbcTemplate {
+    private static final Logger logger = LoggerFactory.getLogger(JdbcTemplate.class);
+
     private static JdbcTemplate jdbcTemplate;
     private DataSource dataSource;
 
@@ -25,7 +30,8 @@ public class JdbcTemplate {
              PreparedStatement pstmt = createPreparedStatement(con, query, objects)) {
             pstmt.executeUpdate();
         } catch (SQLException e) {
-            // TODO: 2019-10-15
+            logger.error("Error occurred while executing Query", e);
+            throw new JdbcTemplateException(e);
         }
     }
 

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -40,6 +40,8 @@ public class JdbcTemplate {
             } catch (SQLException e) {
                 con.rollback();
                 throw e;
+            } finally {
+                con.setAutoCommit(true);
             }
         } catch (Exception e) {
             logger.error("Error occurred while executing Query", e);
@@ -62,6 +64,8 @@ public class JdbcTemplate {
             } catch (SQLException e) {
                 con.rollback();
                 throw e;
+            } finally {
+                con.setAutoCommit(true);
             }
         } catch (Exception e) {
             logger.error("Error occurred while executing Query", e);
@@ -85,6 +89,8 @@ public class JdbcTemplate {
             } catch (SQLException e) {
                 con.rollback();
                 throw e;
+            } finally {
+                con.setAutoCommit(true);
             }
         } catch (Exception e) {
             logger.error("Error occurred while executing Query", e);
@@ -107,6 +113,8 @@ public class JdbcTemplate {
             } catch (SQLException e) {
                 con.rollback();
                 throw e;
+            } finally {
+                con.setAutoCommit(true);
             }
         } catch (Exception e) {
             logger.error("Error occurred while executing Query", e);
@@ -129,6 +137,8 @@ public class JdbcTemplate {
             } catch (SQLException e) {
                 con.rollback();
                 throw e;
+            } finally {
+                con.setAutoCommit(true);
             }
         } catch (Exception e) {
             logger.error("Error occurred while executing Query", e);

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -56,6 +56,22 @@ public class JdbcTemplate {
         return results;
     }
 
+    public <T> List<T> query(String query, RowMapper rowMapper, Object... objects) {
+        List<T> results = new ArrayList<>();
+        try (Connection con = dataSource.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, query, objects);
+             ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                T t = (T) rowMapper.mapRow(rs);
+                results.add(t);
+            }
+        } catch (Exception e) {
+            logger.error("Error occurred while executing Query", e);
+            throw new JdbcTemplateException(e);
+        }
+        return results;
+    }
+
     public <T> T queryForObject(String query, Class<?> clazz, Object... objects) {
         T result = null;
         try (Connection con = dataSource.getConnection();

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -10,6 +10,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class JdbcTemplate {
     private static final Logger logger = LoggerFactory.getLogger(JdbcTemplate.class);
@@ -72,15 +73,15 @@ public class JdbcTemplate {
         return results;
     }
 
-    public <T> T queryForObject(String query, RowMapper<T> rowMapper, Object... objects) {
-        T result = null;
+    public <T> Optional<T> queryForObject(String query, RowMapper<T> rowMapper, Object... objects) {
+        Optional<T> result = Optional.empty();
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, objects);
              ResultSet rs = pstmt.executeQuery()) {
             try {
                 con.setAutoCommit(false);
                 if (rs.next()) {
-                    result = rowMapper.mapRow(rs);
+                    result = Optional.of(rowMapper.mapRow(rs));
                 }
                 con.commit();
             } catch (SQLException e) {

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -32,17 +32,8 @@ public class JdbcTemplate {
     public void executeQuery(String query, Object... objects) {
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, objects)) {
-            try {
-                con.setAutoCommit(false);
-                pstmt.executeUpdate();
-                con.commit();
-            } catch (SQLException e) {
-                con.rollback();
-                throw e;
-            } finally {
-                con.setAutoCommit(true);
-            }
-        } catch (Exception e) {
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
             logger.error("Error occurred while executing Query", e);
             throw new JdbcTemplateException(e);
         }
@@ -53,18 +44,9 @@ public class JdbcTemplate {
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, objects);
              ResultSet rs = pstmt.executeQuery()) {
-            try {
-                con.setAutoCommit(false);
-                while (rs.next()) {
-                    T t = rowMapper.mapRow(rs);
-                    results.add(t);
-                }
-                con.commit();
-            } catch (SQLException e) {
-                con.rollback();
-                throw e;
-            } finally {
-                con.setAutoCommit(true);
+            while (rs.next()) {
+                T t = rowMapper.mapRow(rs);
+                results.add(t);
             }
         } catch (Exception e) {
             logger.error("Error occurred while executing Query", e);
@@ -78,17 +60,8 @@ public class JdbcTemplate {
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, objects);
              ResultSet rs = pstmt.executeQuery()) {
-            try {
-                con.setAutoCommit(false);
-                if (rs.next()) {
-                    result = Optional.of(rowMapper.mapRow(rs));
-                }
-                con.commit();
-            } catch (SQLException e) {
-                con.rollback();
-                throw e;
-            } finally {
-                con.setAutoCommit(true);
+            if (rs.next()) {
+                result = Optional.of(rowMapper.mapRow(rs));
             }
         } catch (Exception e) {
             logger.error("Error occurred while executing Query", e);

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -4,13 +4,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class JdbcTemplate {
@@ -49,31 +47,6 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> List<T> query(String query, Class<?> clazz, Object... objects) {
-        List<T> results = new ArrayList<>();
-        try (Connection con = dataSource.getConnection();
-             PreparedStatement pstmt = createPreparedStatement(con, query, objects);
-             ResultSet rs = pstmt.executeQuery()) {
-            try {
-                con.setAutoCommit(false);
-                while (rs.next()) {
-                    T t = getResult(rs, clazz);
-                    results.add(t);
-                }
-                con.commit();
-            } catch (SQLException e) {
-                con.rollback();
-                throw e;
-            } finally {
-                con.setAutoCommit(true);
-            }
-        } catch (Exception e) {
-            logger.error("Error occurred while executing Query", e);
-            throw new JdbcTemplateException(e);
-        }
-        return results;
-    }
-
     public <T> List<T> query(String query, RowMapper<T> rowMapper, Object... objects) {
         List<T> results = new ArrayList<>();
         try (Connection con = dataSource.getConnection();
@@ -97,30 +70,6 @@ public class JdbcTemplate {
             throw new JdbcTemplateException(e);
         }
         return results;
-    }
-
-    public <T> T queryForObject(String query, Class<?> clazz, Object... objects) {
-        T result = null;
-        try (Connection con = dataSource.getConnection();
-             PreparedStatement pstmt = createPreparedStatement(con, query, objects);
-             ResultSet rs = pstmt.executeQuery()) {
-            try {
-                con.setAutoCommit(false);
-                if (rs.next()) {
-                    result = getResult(rs, clazz);
-                }
-                con.commit();
-            } catch (SQLException e) {
-                con.rollback();
-                throw e;
-            } finally {
-                con.setAutoCommit(true);
-            }
-        } catch (Exception e) {
-            logger.error("Error occurred while executing Query", e);
-            throw new JdbcTemplateException(e);
-        }
-        return result;
     }
 
     public <T> T queryForObject(String query, RowMapper<T> rowMapper, Object... objects) {
@@ -153,21 +102,5 @@ public class JdbcTemplate {
             pstmt.setObject(i + 1, objects[i]);
         }
         return pstmt;
-    }
-
-    private <T> T getResult(ResultSet rs, Class<?> clazz) throws Exception {
-        Object instance = clazz.getDeclaredConstructor().newInstance();
-        Arrays.stream(clazz.getDeclaredFields()).forEach(field -> setField(rs, instance, field));
-        return (T) instance;
-    }
-
-    private void setField(ResultSet rs, Object instance, Field field) {
-        try {
-            field.setAccessible(true);
-            field.set(instance, rs.getObject(field.getName()));
-        } catch (IllegalAccessException | SQLException e) {
-            logger.error("Error occurred while setting Field", e);
-            throw new JdbcTemplateException(e);
-        }
     }
 }

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -39,7 +39,7 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> List<T> query(String query, RowMapper<T> rowMapper, PreparedStatementSetter setter) {
+    public <T> List<T> query(String query, PreparedStatementSetter setter, RowMapper<T> rowMapper) {
         List<T> results = new ArrayList<>();
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, setter);
@@ -55,7 +55,7 @@ public class JdbcTemplate {
         return results;
     }
 
-    public <T> Optional<T> queryForObject(String query, RowMapper<T> rowMapper, PreparedStatementSetter setter) {
+    public <T> Optional<T> queryForObject(String query, PreparedStatementSetter setter, RowMapper<T> rowMapper) {
         Optional<T> result = Optional.empty();
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, setter);

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -70,7 +70,7 @@ public class JdbcTemplate {
         return results;
     }
 
-    public <T> List<T> query(String query, RowMapper rowMapper, Object... objects) {
+    public <T> List<T> query(String query, RowMapper<T> rowMapper, Object... objects) {
         List<T> results = new ArrayList<>();
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, objects);
@@ -78,7 +78,7 @@ public class JdbcTemplate {
             try {
                 con.setAutoCommit(false);
                 while (rs.next()) {
-                    T t = (T) rowMapper.mapRow(rs);
+                    T t = rowMapper.mapRow(rs);
                     results.add(t);
                 }
                 con.commit();
@@ -115,7 +115,7 @@ public class JdbcTemplate {
         return result;
     }
 
-    public <T> T queryForObject(String query, RowMapper rowMapper, Object... objects) {
+    public <T> T queryForObject(String query, RowMapper<T> rowMapper, Object... objects) {
         T result = null;
         try (Connection con = dataSource.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, query, objects);
@@ -123,7 +123,7 @@ public class JdbcTemplate {
             try {
                 con.setAutoCommit(false);
                 if (rs.next()) {
-                    result = (T) rowMapper.mapRow(rs);
+                    result = rowMapper.mapRow(rs);
                 }
                 con.commit();
             } catch (SQLException e) {

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplateException.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/JdbcTemplateException.java
@@ -1,0 +1,7 @@
+package nextstep.jdbc;
+
+public class JdbcTemplateException extends RuntimeException {
+    public JdbcTemplateException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/PreparedStatementSetter.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/PreparedStatementSetter.java
@@ -1,0 +1,9 @@
+package nextstep.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementSetter {
+    void setValues(PreparedStatement pstmt) throws SQLException;
+}

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/RowMapper.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/RowMapper.java
@@ -1,0 +1,7 @@
+package nextstep.jdbc;
+
+import java.sql.ResultSet;
+
+public interface RowMapper <T> {
+    T mapRow(ResultSet rs) throws Exception;
+}

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/RowMapper.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/RowMapper.java
@@ -2,6 +2,7 @@ package nextstep.jdbc;
 
 import java.sql.ResultSet;
 
+@FunctionalInterface
 public interface RowMapper<T> {
     T mapRow(ResultSet rs) throws Exception;
 }

--- a/nextstep-jdbc/src/main/java/nextstep/jdbc/RowMapper.java
+++ b/nextstep-jdbc/src/main/java/nextstep/jdbc/RowMapper.java
@@ -2,6 +2,6 @@ package nextstep.jdbc;
 
 import java.sql.ResultSet;
 
-public interface RowMapper <T> {
+public interface RowMapper<T> {
     T mapRow(ResultSet rs) throws Exception;
 }

--- a/slipp/src/main/java/slipp/controller/ApiUserController.java
+++ b/slipp/src/main/java/slipp/controller/ApiUserController.java
@@ -43,12 +43,13 @@ public class ApiUserController {
     }
 
     @RequestMapping(value = "/api/users", method = RequestMethod.GET)
-    public ModelAndView show(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public ModelAndView show(HttpServletRequest request, HttpServletResponse response) {
         String userId = request.getParameter("userId");
         logger.debug("userId : {}", userId);
 
         ModelAndView mav = new ModelAndView(new JsonView());
-        mav.addObject("user", userDao.findByUserId(userId));
+        userDao.findByUserId(userId)
+                .ifPresent(user -> mav.addObject("user", user));
         return mav;
     }
 
@@ -59,10 +60,11 @@ public class ApiUserController {
         UserUpdatedDto updateDto = objectMapper.readValue(request.getInputStream(), UserUpdatedDto.class);
         logger.debug("Updated User : {}", updateDto);
 
-        User user = userDao.findByUserId(userId);
-        user.update(updateDto);
-        userDao.update(user);
-
+        userDao.findByUserId(userId)
+                .ifPresent(user -> {
+                    user.update(updateDto);
+                    userDao.update(user);
+                });
         return new ModelAndView(new JsonView());
     }
 }

--- a/slipp/src/main/java/slipp/controller/ApiUserController.java
+++ b/slipp/src/main/java/slipp/controller/ApiUserController.java
@@ -9,17 +9,19 @@ import nextstep.web.annotation.RequestMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import slipp.dao.UserDao;
 import slipp.domain.User;
 import slipp.dto.UserCreatedDto;
 import slipp.dto.UserUpdatedDto;
-import slipp.support.db.DataBase;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
 public class ApiUserController {
-    private static final Logger logger = LoggerFactory.getLogger( ApiUserController.class );
+    private static final Logger logger = LoggerFactory.getLogger(ApiUserController.class);
+
+    private final UserDao userDao = UserDao.getInstance();
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -28,8 +30,7 @@ public class ApiUserController {
         UserCreatedDto createdDto = objectMapper.readValue(request.getInputStream(), UserCreatedDto.class);
         logger.debug("Created User : {}", createdDto);
 
-
-        DataBase.addUser(new User(
+        userDao.insert(new User(
                 createdDto.getUserId(),
                 createdDto.getPassword(),
                 createdDto.getName(),
@@ -47,7 +48,7 @@ public class ApiUserController {
         logger.debug("userId : {}", userId);
 
         ModelAndView mav = new ModelAndView(new JsonView());
-        mav.addObject("user", DataBase.findUserById(userId));
+        mav.addObject("user", userDao.findByUserId(userId));
         return mav;
     }
 
@@ -58,8 +59,9 @@ public class ApiUserController {
         UserUpdatedDto updateDto = objectMapper.readValue(request.getInputStream(), UserUpdatedDto.class);
         logger.debug("Updated User : {}", updateDto);
 
-        User user = DataBase.findUserById(userId);
+        User user = userDao.findByUserId(userId);
         user.update(updateDto);
+        userDao.update(user);
 
         return new ModelAndView(new JsonView());
     }

--- a/slipp/src/main/java/slipp/controller/HomeController.java
+++ b/slipp/src/main/java/slipp/controller/HomeController.java
@@ -1,15 +1,18 @@
 package slipp.controller;
 
-import slipp.support.db.DataBase;
 import nextstep.mvc.asis.Controller;
+import slipp.dao.UserDao;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class HomeController implements Controller {
+
+    private final UserDao userDao = UserDao.getInstance();
+
     @Override
     public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
-        req.setAttribute("users", DataBase.findAll());
+        req.setAttribute("users", userDao.findAll());
         return "home.jsp";
     }
 }

--- a/slipp/src/main/java/slipp/controller/LoginController.java
+++ b/slipp/src/main/java/slipp/controller/LoginController.java
@@ -1,19 +1,22 @@
 package slipp.controller;
 
-import slipp.domain.User;
-import slipp.support.db.DataBase;
 import nextstep.mvc.asis.Controller;
+import slipp.dao.UserDao;
+import slipp.domain.User;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 public class LoginController implements Controller {
+
+    private final UserDao userDao = UserDao.getInstance();
+
     @Override
     public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         String userId = req.getParameter("userId");
         String password = req.getParameter("password");
-        User user = DataBase.findUserById(userId);
+        User user = userDao.findByUserId(userId);
         if (user == null) {
             req.setAttribute("loginFailed", true);
             return "/user/login.jsp";

--- a/slipp/src/main/java/slipp/controller/LoginController.java
+++ b/slipp/src/main/java/slipp/controller/LoginController.java
@@ -2,7 +2,6 @@ package slipp.controller;
 
 import nextstep.mvc.asis.Controller;
 import slipp.dao.UserDao;
-import slipp.domain.User;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -13,21 +12,19 @@ public class LoginController implements Controller {
     private final UserDao userDao = UserDao.getInstance();
 
     @Override
-    public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+    public String execute(HttpServletRequest req, HttpServletResponse resp) {
         String userId = req.getParameter("userId");
         String password = req.getParameter("password");
-        User user = userDao.findByUserId(userId);
-        if (user == null) {
-            req.setAttribute("loginFailed", true);
-            return "/user/login.jsp";
-        }
-        if (user.matchPassword(password)) {
-            HttpSession session = req.getSession();
-            session.setAttribute(UserSessionUtils.USER_SESSION_KEY, user);
-            return "redirect:/";
-        } else {
-            req.setAttribute("loginFailed", true);
-            return "/user/login.jsp";
-        }
+
+        return userDao.findByUserId(userId)
+                .filter(user -> user.matchPassword(password))
+                .map(user -> {
+                    HttpSession session = req.getSession();
+                    session.setAttribute(UserSessionUtils.USER_SESSION_KEY, user);
+                    return "redirect:/";
+                }).orElseGet(() -> {
+                    req.setAttribute("loginFailed", true);
+                    return "/user/login.jsp";
+                });
     }
 }

--- a/slipp/src/main/java/slipp/controller/ProfileController.java
+++ b/slipp/src/main/java/slipp/controller/ProfileController.java
@@ -1,17 +1,20 @@
 package slipp.controller;
 
-import slipp.domain.User;
-import slipp.support.db.DataBase;
 import nextstep.mvc.asis.Controller;
+import slipp.dao.UserDao;
+import slipp.domain.User;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class ProfileController implements Controller {
+
+    private final UserDao userDao = UserDao.getInstance();
+
     @Override
     public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         String userId = req.getParameter("userId");
-        User user = DataBase.findUserById(userId);
+        User user = userDao.findByUserId(userId);
         if (user == null) {
             throw new NullPointerException("사용자를 찾을 수 없습니다.");
         }

--- a/slipp/src/main/java/slipp/controller/ProfileController.java
+++ b/slipp/src/main/java/slipp/controller/ProfileController.java
@@ -2,7 +2,6 @@ package slipp.controller;
 
 import nextstep.mvc.asis.Controller;
 import slipp.dao.UserDao;
-import slipp.domain.User;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -12,13 +11,15 @@ public class ProfileController implements Controller {
     private final UserDao userDao = UserDao.getInstance();
 
     @Override
-    public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+    public String execute(HttpServletRequest req, HttpServletResponse resp) {
         String userId = req.getParameter("userId");
-        User user = userDao.findByUserId(userId);
-        if (user == null) {
-            throw new NullPointerException("사용자를 찾을 수 없습니다.");
-        }
-        req.setAttribute("user", user);
-        return "/user/profile.jsp";
+
+        return userDao.findByUserId(userId)
+                .map(user -> {
+                    req.setAttribute("user", user);
+                    return "/user/profile.jsp";
+                }).orElseThrow(() -> {
+                    throw new NullPointerException("사용자를 찾을 수 없습니다.");
+                });
     }
 }

--- a/slipp/src/main/java/slipp/controller/UpdateFormUserController.java
+++ b/slipp/src/main/java/slipp/controller/UpdateFormUserController.java
@@ -2,7 +2,6 @@ package slipp.controller;
 
 import nextstep.mvc.asis.Controller;
 import slipp.dao.UserDao;
-import slipp.domain.User;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -12,13 +11,16 @@ public class UpdateFormUserController implements Controller {
     private final UserDao userDao = UserDao.getInstance();
 
     @Override
-    public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+    public String execute(HttpServletRequest req, HttpServletResponse resp) {
         String userId = req.getParameter("userId");
-        User user = userDao.findByUserId(userId);
-        if (!UserSessionUtils.isSameUser(req.getSession(), user)) {
-            throw new IllegalStateException("다른 사용자의 정보를 수정할 수 없습니다.");
-        }
-        req.setAttribute("user", user);
-        return "/user/updateForm.jsp";
+
+        return userDao.findByUserId(userId)
+                .filter(user -> UserSessionUtils.isSameUser(req.getSession(), user))
+                .map(user -> {
+                    req.setAttribute("user", user);
+                    return "/user/updateForm.jsp";
+                }).orElseThrow(() -> {
+                    throw new IllegalStateException("다른 사용자의 정보를 수정할 수 없습니다.");
+                });
     }
 }

--- a/slipp/src/main/java/slipp/controller/UpdateFormUserController.java
+++ b/slipp/src/main/java/slipp/controller/UpdateFormUserController.java
@@ -1,18 +1,20 @@
 package slipp.controller;
 
-import slipp.domain.User;
-import slipp.support.db.DataBase;
 import nextstep.mvc.asis.Controller;
+import slipp.dao.UserDao;
+import slipp.domain.User;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class UpdateFormUserController implements Controller {
 
+    private final UserDao userDao = UserDao.getInstance();
+
     @Override
     public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         String userId = req.getParameter("userId");
-        User user = DataBase.findUserById(userId);
+        User user = userDao.findByUserId(userId);
         if (!UserSessionUtils.isSameUser(req.getSession(), user)) {
             throw new IllegalStateException("다른 사용자의 정보를 수정할 수 없습니다.");
         }

--- a/slipp/src/main/java/slipp/controller/UpdateUserController.java
+++ b/slipp/src/main/java/slipp/controller/UpdateUserController.java
@@ -1,11 +1,11 @@
 package slipp.controller;
 
-import slipp.domain.User;
-import slipp.dto.UserUpdatedDto;
-import slipp.support.db.DataBase;
 import nextstep.mvc.asis.Controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import slipp.dao.UserDao;
+import slipp.domain.User;
+import slipp.dto.UserUpdatedDto;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -13,9 +13,11 @@ import javax.servlet.http.HttpServletResponse;
 public class UpdateUserController implements Controller {
     private static final Logger log = LoggerFactory.getLogger(UpdateUserController.class);
 
+    private final UserDao userDao = UserDao.getInstance();
+
     @Override
     public String execute(HttpServletRequest req, HttpServletResponse resp) throws Exception {
-        User user = DataBase.findUserById(req.getParameter("userId"));
+        User user = userDao.findByUserId(req.getParameter("userId"));
         if (!UserSessionUtils.isSameUser(req.getSession(), user)) {
             throw new IllegalStateException("다른 사용자의 정보를 수정할 수 없습니다.");
         }
@@ -26,6 +28,7 @@ public class UpdateUserController implements Controller {
                 req.getParameter("email"));
         log.debug("Update User : {}", updateUser);
         user.update(updateUser);
+        userDao.update(user);
         return "redirect:/";
     }
 }

--- a/slipp/src/main/java/slipp/controller/UserController.java
+++ b/slipp/src/main/java/slipp/controller/UserController.java
@@ -7,8 +7,8 @@ import nextstep.web.annotation.RequestMapping;
 import nextstep.web.annotation.RequestMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import slipp.dao.UserDao;
 import slipp.domain.User;
-import slipp.support.db.DataBase;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -16,6 +16,8 @@ import javax.servlet.http.HttpServletResponse;
 @Controller
 public class UserController {
     private static final Logger logger = LoggerFactory.getLogger(UserController.class);
+
+    private final UserDao userDao = UserDao.getInstance();
 
     @RequestMapping(value = "/users/create", method = RequestMethod.POST)
     public ModelAndView create(HttpServletRequest req, HttpServletResponse resp) throws Exception {
@@ -25,7 +27,7 @@ public class UserController {
                 req.getParameter("name"),
                 req.getParameter("email"));
         logger.debug("User : {}", user);
-        DataBase.addUser(user);
+        userDao.insert(user);
         return redirect("/");
     }
 
@@ -41,7 +43,7 @@ public class UserController {
         }
 
         ModelAndView mav = new ModelAndView(new JspView("/user/list.jsp"));
-        mav.addObject("users", DataBase.findAll());
+        mav.addObject("users", userDao.findAll());
         return mav;
     }
 }

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -8,6 +8,7 @@ import slipp.support.db.ConnectionManager;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class UserDao {
@@ -30,8 +31,18 @@ public class UserDao {
         );
     }
 
+//    public List<User> findAll() {
+//        return jdbcTemplate.query("SELECT userId, password, name, email FROM USERS", User.class);
+//    }
+
     public List<User> findAll() {
-        return jdbcTemplate.query("SELECT userId, password, name, email FROM USERS", User.class);
+        return jdbcTemplate.query(
+                "SELECT userId, password, name, email FROM USERS",
+                rs -> new User(
+                        rs.getString("userId"),
+                        rs.getString("password"),
+                        rs.getString("name"),
+                        rs.getString("email")));
     }
 
     public User findByUserId(String userId) {

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -36,12 +36,59 @@ public class UserDao {
     }
 
     public void update(User user) throws SQLException {
-        // TODO 구현 필요함.
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        try {
+            con = ConnectionManager.getConnection();
+            String sql = "UPDATE USERS SET password = ?, name = ?, email = ? WHERE userId = ?";
+            pstmt = con.prepareStatement(sql);
+            pstmt.setString(1, user.getPassword());
+            pstmt.setString(2, user.getName());
+            pstmt.setString(3, user.getEmail());
+            pstmt.setString(4, user.getUserId());
+
+            pstmt.executeUpdate();
+        } finally {
+            if (pstmt != null) {
+                pstmt.close();
+            }
+
+            if (con != null) {
+                con.close();
+            }
+        }
     }
 
     public List<User> findAll() throws SQLException {
-        // TODO 구현 필요함.
-        return new ArrayList<User>();
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        List<User> users = new ArrayList<>();
+        try {
+            con = ConnectionManager.getConnection();
+            String sql = "SELECT userId, password, name, email FROM USERS";
+            pstmt = con.prepareStatement(sql);
+
+            rs = pstmt.executeQuery();
+
+            User user = null;
+            while (rs.next()) {
+                user = new User(rs.getString("userId"), rs.getString("password"), rs.getString("name"),
+                        rs.getString("email"));
+                users.add(user);
+            }
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (pstmt != null) {
+                pstmt.close();
+            }
+            if (con != null) {
+                con.close();
+            }
+        }
+        return users;
     }
 
     public User findByUserId(String userId) throws SQLException {

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -5,6 +5,7 @@ import slipp.domain.User;
 import slipp.support.db.ConnectionManager;
 
 import java.util.List;
+import java.util.Optional;
 
 public class UserDao {
     private JdbcTemplate jdbcTemplate;
@@ -44,7 +45,7 @@ public class UserDao {
                         rs.getString("email")));
     }
 
-    public User findByUserId(String userId) {
+    public Optional<User> findByUserId(String userId) {
         return jdbcTemplate.queryForObject(
                 "SELECT userId, password, name, email FROM USERS WHERE userId=?",
                 rs -> new User(

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -12,64 +12,35 @@ import java.util.List;
 
 public class UserDao {
     public void insert(User user) throws SQLException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        try {
-            con = ConnectionManager.getConnection();
-            String sql = "INSERT INTO USERS VALUES (?, ?, ?, ?)";
-            pstmt = con.prepareStatement(sql);
-            pstmt.setString(1, user.getUserId());
-            pstmt.setString(2, user.getPassword());
-            pstmt.setString(3, user.getName());
-            pstmt.setString(4, user.getEmail());
+        try (Connection con = ConnectionManager.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, "INSERT INTO USERS VALUES (?, ?, ?, ?)",
+                     user.getUserId(), user.getPassword(), user.getName(), user.getEmail())) {
 
             pstmt.executeUpdate();
-        } finally {
-            if (pstmt != null) {
-                pstmt.close();
-            }
-
-            if (con != null) {
-                con.close();
-            }
         }
     }
 
+    private PreparedStatement createPreparedStatement(Connection con, String sql, Object... objects) throws SQLException {
+        PreparedStatement pstmt = con.prepareStatement(sql);
+        for (int i = 0; i < objects.length; i++) {
+            pstmt.setObject(i + 1, objects[i]);
+        }
+        return pstmt;
+    }
+
     public void update(User user) throws SQLException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        try {
-            con = ConnectionManager.getConnection();
-            String sql = "UPDATE USERS SET password = ?, name = ?, email = ? WHERE userId = ?";
-            pstmt = con.prepareStatement(sql);
-            pstmt.setString(1, user.getPassword());
-            pstmt.setString(2, user.getName());
-            pstmt.setString(3, user.getEmail());
-            pstmt.setString(4, user.getUserId());
-
+        try (Connection con = ConnectionManager.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, "UPDATE USERS SET password = ?, name = ?, email = ? WHERE userId = ?",
+                     user.getPassword(), user.getName(), user.getEmail(), user.getUserId())) {
             pstmt.executeUpdate();
-        } finally {
-            if (pstmt != null) {
-                pstmt.close();
-            }
-
-            if (con != null) {
-                con.close();
-            }
         }
     }
 
     public List<User> findAll() throws SQLException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
         List<User> users = new ArrayList<>();
-        try {
-            con = ConnectionManager.getConnection();
-            String sql = "SELECT userId, password, name, email FROM USERS";
-            pstmt = con.prepareStatement(sql);
-
-            rs = pstmt.executeQuery();
+        try (Connection con = ConnectionManager.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, "SELECT userId, password, name, email FROM USERS");
+             ResultSet rs = pstmt.executeQuery()) {
 
             User user = null;
             while (rs.next()) {
@@ -77,32 +48,15 @@ public class UserDao {
                         rs.getString("email"));
                 users.add(user);
             }
-        } finally {
-            if (rs != null) {
-                rs.close();
-            }
-            if (pstmt != null) {
-                pstmt.close();
-            }
-            if (con != null) {
-                con.close();
-            }
         }
         return users;
     }
 
     public User findByUserId(String userId) throws SQLException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = ConnectionManager.getConnection();
-            String sql = "SELECT userId, password, name, email FROM USERS WHERE userid=?";
-            pstmt = con.prepareStatement(sql);
-            pstmt.setString(1, userId);
-
-            rs = pstmt.executeQuery();
-
+        try (Connection con = ConnectionManager.getConnection();
+             PreparedStatement pstmt = createPreparedStatement(con, "SELECT userId, password, name, email FROM USERS WHERE userid=?", userId);
+             ResultSet rs = pstmt.executeQuery()) {
+            
             User user = null;
             if (rs.next()) {
                 user = new User(rs.getString("userId"), rs.getString("password"), rs.getString("name"),
@@ -110,16 +64,6 @@ public class UserDao {
             }
 
             return user;
-        } finally {
-            if (rs != null) {
-                rs.close();
-            }
-            if (pstmt != null) {
-                pstmt.close();
-            }
-            if (con != null) {
-                con.close();
-            }
         }
     }
 }

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -9,8 +9,16 @@ import java.util.List;
 public class UserDao {
     private JdbcTemplate jdbcTemplate;
 
-    public UserDao() {
+    private UserDao() {
         this.jdbcTemplate = JdbcTemplate.getInstance(ConnectionManager.getDataSource());
+    }
+
+    private static class LazyHolder {
+        private static final UserDao INSTANCE = new UserDao();
+    }
+
+    public static UserDao getInstance() {
+        return LazyHolder.INSTANCE;
     }
 
     public void insert(User user) {

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -34,10 +34,6 @@ public class UserDao {
         );
     }
 
-//    public List<User> findAll() {
-//        return jdbcTemplate.query("SELECT userId, password, name, email FROM USERS", User.class);
-//    }
-
     public List<User> findAll() {
         return jdbcTemplate.query(
                 "SELECT userId, password, name, email FROM USERS",
@@ -50,19 +46,12 @@ public class UserDao {
 
     public User findByUserId(String userId) {
         return jdbcTemplate.queryForObject(
-                "SELECT userId, password, name, email FROM USERS WHERE userid=?",
-                User.class,
+                "SELECT userId, password, name, email FROM USERS WHERE userId=?",
+                rs -> new User(
+                        rs.getString("userId"),
+                        rs.getString("password"),
+                        rs.getString("name"),
+                        rs.getString("email")),
                 userId);
     }
-
-    /*public User findByUserId(String userId) {
-        return jdbcTemplate.queryForObject(
-                "SELECT userId, password, name, email FROM USERS WHERE userid=?",
-                    rs -> new User(
-                                rs.getString("userId"),
-                                rs.getString("password"),
-                                rs.getString("name"),
-                                rs.getString("email")),
-                userId);
-    }*/
 }

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -1,9 +1,13 @@
 package slipp.dao;
 
 import nextstep.jdbc.JdbcTemplate;
+import nextstep.jdbc.RowMapper;
 import slipp.domain.User;
 import slipp.support.db.ConnectionManager;
 
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.ArrayList;
 import java.util.List;
 
 public class UserDao {
@@ -36,4 +40,15 @@ public class UserDao {
                 User.class,
                 userId);
     }
+
+    /*public User findByUserId(String userId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT userId, password, name, email FROM USERS WHERE userid=?",
+                    rs -> new User(
+                                rs.getString("userId"),
+                                rs.getString("password"),
+                                rs.getString("name"),
+                                rs.getString("email")),
+                userId);
+    }*/
 }

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -1,14 +1,9 @@
 package slipp.dao;
 
 import nextstep.jdbc.JdbcTemplate;
-import nextstep.jdbc.RowMapper;
 import slipp.domain.User;
 import slipp.support.db.ConnectionManager;
 
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class UserDao {
@@ -20,7 +15,7 @@ public class UserDao {
 
     public void insert(User user) {
         jdbcTemplate.executeQuery(
-                "INSERT INTO USERS VALUES (?, ?, ?, ?)",
+                "INSERT INTO USERS (userId, password, name, email) VALUES (?, ?, ?, ?)",
                 user.getUserId(), user.getPassword(), user.getName(), user.getEmail());
     }
 

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -25,14 +25,23 @@ public class UserDao {
     public void insert(User user) {
         jdbcTemplate.executeQuery(
                 "INSERT INTO USERS (userId, password, name, email) VALUES (?, ?, ?, ?)",
-                user.getUserId(), user.getPassword(), user.getName(), user.getEmail());
+                pstmt -> {
+                    pstmt.setObject(1, user.getUserId());
+                    pstmt.setObject(2, user.getPassword());
+                    pstmt.setObject(3, user.getName());
+                    pstmt.setObject(4, user.getEmail());
+                });
     }
 
     public void update(User user) {
         jdbcTemplate.executeQuery(
                 "UPDATE USERS SET password = ?, name = ?, email = ? WHERE userId = ?",
-                user.getPassword(), user.getName(), user.getEmail(), user.getUserId()
-        );
+                pstmt -> {
+                    pstmt.setObject(1, user.getPassword());
+                    pstmt.setObject(2, user.getName());
+                    pstmt.setObject(3, user.getEmail());
+                    pstmt.setObject(4, user.getUserId());
+                });
     }
 
     public List<User> findAll() {
@@ -42,7 +51,9 @@ public class UserDao {
                         rs.getString("userId"),
                         rs.getString("password"),
                         rs.getString("name"),
-                        rs.getString("email")));
+                        rs.getString("email")),
+                pstmt -> {
+                });
     }
 
     public Optional<User> findByUserId(String userId) {
@@ -53,6 +64,6 @@ public class UserDao {
                         rs.getString("password"),
                         rs.getString("name"),
                         rs.getString("email")),
-                userId);
+                pstmt -> pstmt.setObject(1, userId));
     }
 }

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -1,5 +1,6 @@
 package slipp.dao;
 
+import nextstep.jdbc.JdbcTemplate;
 import slipp.domain.User;
 import slipp.support.db.ConnectionManager;
 
@@ -11,13 +12,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class UserDao {
-    public void insert(User user) throws SQLException {
-        try (Connection con = ConnectionManager.getConnection();
-             PreparedStatement pstmt = createPreparedStatement(con, "INSERT INTO USERS VALUES (?, ?, ?, ?)",
-                     user.getUserId(), user.getPassword(), user.getName(), user.getEmail())) {
+    private JdbcTemplate jdbcTemplate;
 
-            pstmt.executeUpdate();
-        }
+    public UserDao() {
+        this.jdbcTemplate = JdbcTemplate.getInstance(ConnectionManager.getDataSource());
+    }
+
+    public void insert(User user) {
+        jdbcTemplate.executeQuery(
+                "INSERT INTO USERS VALUES (?, ?, ?, ?)",
+                user.getUserId(), user.getPassword(), user.getName(), user.getEmail());
     }
 
     private PreparedStatement createPreparedStatement(Connection con, String sql, Object... objects) throws SQLException {

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -4,10 +4,6 @@ import nextstep.jdbc.JdbcTemplate;
 import slipp.domain.User;
 import slipp.support.db.ConnectionManager;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 
 public class UserDao {
@@ -23,14 +19,6 @@ public class UserDao {
                 user.getUserId(), user.getPassword(), user.getName(), user.getEmail());
     }
 
-    private PreparedStatement createPreparedStatement(Connection con, String sql, Object... objects) throws SQLException {
-        PreparedStatement pstmt = con.prepareStatement(sql);
-        for (int i = 0; i < objects.length; i++) {
-            pstmt.setObject(i + 1, objects[i]);
-        }
-        return pstmt;
-    }
-
     public void update(User user) {
         jdbcTemplate.executeQuery(
                 "UPDATE USERS SET password = ?, name = ?, email = ? WHERE userId = ?",
@@ -42,18 +30,10 @@ public class UserDao {
         return jdbcTemplate.query("SELECT userId, password, name, email FROM USERS", User.class);
     }
 
-    public User findByUserId(String userId) throws SQLException {
-        try (Connection con = ConnectionManager.getConnection();
-             PreparedStatement pstmt = createPreparedStatement(con, "SELECT userId, password, name, email FROM USERS WHERE userid=?", userId);
-             ResultSet rs = pstmt.executeQuery()) {
-
-            User user = null;
-            if (rs.next()) {
-                user = new User(rs.getString("userId"), rs.getString("password"), rs.getString("name"),
-                        rs.getString("email"));
-            }
-
-            return user;
-        }
+    public User findByUserId(String userId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT userId, password, name, email FROM USERS WHERE userid=?",
+                User.class,
+                userId);
     }
 }

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -8,7 +8,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class UserDao {
@@ -39,20 +38,8 @@ public class UserDao {
         );
     }
 
-    public List<User> findAll() throws SQLException {
-        List<User> users = new ArrayList<>();
-        try (Connection con = ConnectionManager.getConnection();
-             PreparedStatement pstmt = createPreparedStatement(con, "SELECT userId, password, name, email FROM USERS");
-             ResultSet rs = pstmt.executeQuery()) {
-
-            User user = null;
-            while (rs.next()) {
-                user = new User(rs.getString("userId"), rs.getString("password"), rs.getString("name"),
-                        rs.getString("email"));
-                users.add(user);
-            }
-        }
-        return users;
+    public List<User> findAll() {
+        return jdbcTemplate.query("SELECT userId, password, name, email FROM USERS", User.class);
     }
 
     public User findByUserId(String userId) throws SQLException {

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -32,12 +32,11 @@ public class UserDao {
         return pstmt;
     }
 
-    public void update(User user) throws SQLException {
-        try (Connection con = ConnectionManager.getConnection();
-             PreparedStatement pstmt = createPreparedStatement(con, "UPDATE USERS SET password = ?, name = ?, email = ? WHERE userId = ?",
-                     user.getPassword(), user.getName(), user.getEmail(), user.getUserId())) {
-            pstmt.executeUpdate();
-        }
+    public void update(User user) {
+        jdbcTemplate.executeQuery(
+                "UPDATE USERS SET password = ?, name = ?, email = ? WHERE userId = ?",
+                user.getPassword(), user.getName(), user.getEmail(), user.getUserId()
+        );
     }
 
     public List<User> findAll() throws SQLException {
@@ -60,7 +59,7 @@ public class UserDao {
         try (Connection con = ConnectionManager.getConnection();
              PreparedStatement pstmt = createPreparedStatement(con, "SELECT userId, password, name, email FROM USERS WHERE userid=?", userId);
              ResultSet rs = pstmt.executeQuery()) {
-            
+
             User user = null;
             if (rs.next()) {
                 user = new User(rs.getString("userId"), rs.getString("password"), rs.getString("name"),

--- a/slipp/src/main/java/slipp/dao/UserDao.java
+++ b/slipp/src/main/java/slipp/dao/UserDao.java
@@ -47,23 +47,23 @@ public class UserDao {
     public List<User> findAll() {
         return jdbcTemplate.query(
                 "SELECT userId, password, name, email FROM USERS",
-                rs -> new User(
+                pstmt -> {
+                }, rs -> new User(
                         rs.getString("userId"),
                         rs.getString("password"),
                         rs.getString("name"),
-                        rs.getString("email")),
-                pstmt -> {
-                });
+                        rs.getString("email"))
+        );
     }
 
     public Optional<User> findByUserId(String userId) {
         return jdbcTemplate.queryForObject(
                 "SELECT userId, password, name, email FROM USERS WHERE userId=?",
-                rs -> new User(
+                pstmt -> pstmt.setObject(1, userId), rs -> new User(
                         rs.getString("userId"),
                         rs.getString("password"),
                         rs.getString("name"),
-                        rs.getString("email")),
-                pstmt -> pstmt.setObject(1, userId));
+                        rs.getString("email"))
+        );
     }
 }

--- a/slipp/src/test/java/slipp/controller/UserAcceptanceTest.java
+++ b/slipp/src/test/java/slipp/controller/UserAcceptanceTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import slipp.domain.User;
 import slipp.dto.UserCreatedDto;
 import slipp.dto.UserUpdatedDto;
-import slipp.domain.User;
 import support.test.NsWebTestClient;
 
 import java.net.URI;

--- a/slipp/src/test/java/slipp/dao/UserDaoTest.java
+++ b/slipp/src/test/java/slipp/dao/UserDaoTest.java
@@ -22,7 +22,7 @@ public class UserDaoTest {
     }
 
     @Test
-    public void crud() throws Exception {
+    public void crud() {
         User expected = new User("userId", "password", "name", "javajigi@email.com");
         UserDao userDao = new UserDao();
         userDao.insert(expected);

--- a/slipp/src/test/java/slipp/dao/UserDaoTest.java
+++ b/slipp/src/test/java/slipp/dao/UserDaoTest.java
@@ -36,7 +36,7 @@ public class UserDaoTest {
     }
 
     @Test
-    public void findAll() throws Exception {
+    public void findAll() {
         UserDao userDao = new UserDao();
         List<User> users = userDao.findAll();
         assertThat(users).hasSize(1);

--- a/slipp/src/test/java/slipp/dao/UserDaoTest.java
+++ b/slipp/src/test/java/slipp/dao/UserDaoTest.java
@@ -24,7 +24,7 @@ public class UserDaoTest {
     @Test
     public void crud() {
         User expected = new User("userId", "password", "name", "javajigi@email.com");
-        UserDao userDao = new UserDao();
+        UserDao userDao = UserDao.getInstance();
         userDao.insert(expected);
         User actual = userDao.findByUserId(expected.getUserId());
         assertThat(actual).isEqualTo(expected);
@@ -37,7 +37,7 @@ public class UserDaoTest {
 
     @Test
     public void findAll() {
-        UserDao userDao = new UserDao();
+        UserDao userDao = UserDao.getInstance();
         List<User> users = userDao.findAll();
         assertThat(users).hasSize(1);
     }

--- a/slipp/src/test/java/slipp/dao/UserDaoTest.java
+++ b/slipp/src/test/java/slipp/dao/UserDaoTest.java
@@ -10,6 +10,7 @@ import slipp.dto.UserUpdatedDto;
 import slipp.support.db.ConnectionManager;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,13 +26,20 @@ public class UserDaoTest {
     public void crud() {
         User expected = new User("userId", "password", "name", "javajigi@email.com");
         UserDao userDao = UserDao.getInstance();
+
         userDao.insert(expected);
-        User actual = userDao.findByUserId(expected.getUserId());
+        Optional<User> maybeUser = userDao.findByUserId(expected.getUserId());
+        assertThat(maybeUser.isPresent()).isTrue();
+
+        User actual = maybeUser.get();
         assertThat(actual).isEqualTo(expected);
 
         expected.update(new UserUpdatedDto("password2", "name2", "sanjigi@email.com"));
         userDao.update(expected);
-        actual = userDao.findByUserId(expected.getUserId());
+        maybeUser = userDao.findByUserId(expected.getUserId());
+        assertThat(maybeUser.isPresent()).isTrue();
+
+        actual = maybeUser.get();
         assertThat(actual).isEqualTo(expected);
     }
 


### PR DESCRIPTION
안녕하세요 브리님! JDBC미션 제출합니다!
잘부탁드립니다 😃 

---

#### 참고&질문 사항

- JdbcTemplate에서 트랜잭션을 관리하도록 하는 과정에서, try-with-resource문의 catch에선 connection을 다룰수없어서, try문안에 별도의 try-catch문을 작성해 commit/rollback을 시켜줘야했습니다. 혹시 이런방식외에 다른 방법도 있을까요 ?

- 현재 JdbcTemplate에서 ResultSet은 리턴할 객체를 만들어주는 방법으로 2가지를 구현해보았습니다. Reflection을 이용한 방법과 RowMapper를 이용한 방법입니다. 결국 UserDao에서 JdbcTemplate에 'User를 어떻게 만들것인지'에 대한 방법을 제공해야하는데, 어느 방식이 나을지 고민되어 조언을 구하고 싶습니다..! (RowMapper방식도 좋지만, 리플렉션방식도 User.class만 넘기면 되기때문에, 프레임워크 사용자입장에선 편할거라 생각했습니다!)
  - (추가) 이부분은 다시 생각해보니, 리플랙션을 사용하면 객체생성방식이 획일화되어서 유연성이 떨어질수도 있을것같습니다! (예를 들어, 필드와 생성자가 여러개인 경우에도, 무조건 모든 필드를 긁어와 초기화) 때문에, 오류가 발생할 수도 있고 UserDao가 방법을 정하도록 하는게 나을것같습니다 ! 😃 

- 현재 제 코드의 JdbcTemplate은 `Object... objects`처럼 가변인자로 받고 있는데요, 저희 강의자료의 1단계리팩토링힌트를 보면 PreparedStatementSetter를 확인할수있었습니다. 현재 방식에서 PreparedStatementSetter를 추가하는것이 createPreparedStatement 메소드를 분리하는 것일뿐, 무의미하다고 생각되어서 아직 별도 클래스로 구현하지 않았는데, 이부분도 혹시 제가 생각치못한 PreparedStatementSetter의 역할이 있는건지 궁금해서 여쭤보고싶습니다!

- [Spring의 singleton과 Java static기반 singleton패턴의 차이](https://enterkey.tistory.com/300) 글을 읽고, 싱글 인스턴스를 보장하는 방법에도 차이가 있다는 걸 알게 되었습니다. 스프링은 맨 처음에 딱 한번만 생성된 인스턴스를 **주입**해서 싱글턴을 보장하는것같습니다. 반면 현재 제 코드의 UserDao는 LazyHolder를 이용한 일반적인 static방식의 싱글턴 기법을 이용해, 싱글 인스턴스를 보장하고있습니다. 현재의 UserDao 방식에서 스프링처럼 싱글턴을 보장해주려면, ManualHandlerMapping#initialize에서 컨트롤러 생성자에 UserDao를 넣어주는 방법밖에 생각나지않아서, 이부분도 조언을 구하고 싶습니다.. `@Autowired`와 같은 어노테이션을 만들어줘야할까요...? 😢 
(제가 생각한 static기반의 싱글톤패턴보다 스프링의 주입방식이 더 나은 이유는, static기반의 getInstance를 통한 객체획득보다 주입받는것이 테스트가 쉽고 & 위의 링크에서 언급된대로 static방식은 다른 서블릿간에 같은 인스턴스가 참조되어 sideEffect가 생길수있기때문(?)입니다 !)

감사합니다 !!! :)